### PR TITLE
fix: add unreleased changes to CHANGELOG.md

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-05-08
+### Added
+- Initial outbox library implementation
+- Maven build configuration with javadocs and sources plugins
+- CI/CD workflows for release and testing
 
-[Unreleased]: https://github.com/InditexTech/scs-outbox/compare/0.1.0...HEAD
-
-[0.1.0]: https://github.com/InditexTech/scs-outbox/releases/tag/0.1.0


### PR DESCRIPTION
## Summary
- Adds entries under `[Unreleased]` section in CHANGELOG.md to unblock the release workflow
- Removes the `[0.1.0]` section since the tag was deleted and the release never completed

## Context
Both workflow runs failed because the `[Unreleased]` section was empty:
- https://github.com/InditexTech/scs-outbox/actions/runs/25555432005
- https://github.com/InditexTech/scs-outbox/actions/runs/25548957503