### PR TITLE
feat: Configure Dependabot for Maven updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven" 
+    directory: "/code" 
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Updated Dependabot configuration to specify Maven as the package ecosystem and changed the directory to '/code'.

