### PR TITLE
outboxExecutorService silently adopts any ExecutorService bean instead of requiring the exact bean name

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `outboxExecutorService` no longer silently adopts an unrelated `ExecutorService` bean (including one marked `@Primary`) present elsewhere
+  in the application context. It is now only satisfied by a bean explicitly named `outboxExecutorService` or by the library's own default,
+  matching the documented override contract. **This is a potentially breaking change** for applications relying on the previous
+  undocumented by-type/`@Primary` fallback; define a bean explicitly named `outboxExecutorService` to keep using a custom executor.
+
 ## [1.0.0] - 2026-06-03
 
 ## [0.2.0] - 2026-06-03

--- a/code/scs-outbox-libs/scs-outbox-core/src/main/java/dev/inditex/scsoutbox/config/OutboxAutoConfiguration.java
+++ b/code/scs-outbox-libs/scs-outbox-core/src/main/java/dev/inditex/scsoutbox/config/OutboxAutoConfiguration.java
@@ -140,19 +140,14 @@ public class OutboxAutoConfiguration {
   }
 
   /**
-   * Default executor service.
+   * Default executor service used by {@code ParallelPublisher}. Backs off entirely if a bean is explicitly named
+   * {@code outboxExecutorService} (no by-type/{@code @Primary} fallback), since {@code ExecutorService} beans are common in typical Spring
+   * Boot applications and picking one up unintentionally could route outbox publishing to an unrelated pool.
    */
-  @ConditionalOnMissingBean
+  @ConditionalOnMissingBean(name = {OUTBOX_EXECUTOR_SERVICE_BEAN_NAME})
   @Bean(name = {DEFAULT_OUTBOX_EXECUTOR_SERVICE_BEAN_NAME, OUTBOX_EXECUTOR_SERVICE_BEAN_NAME})
   public ExecutorService defaultOutboxExecutorService() {
     return Executors.newCachedThreadPool();
-  }
-
-  @ConditionalOnMissingBean(name = {OUTBOX_EXECUTOR_SERVICE_BEAN_NAME})
-  @Bean(OUTBOX_EXECUTOR_SERVICE_BEAN_NAME)
-  public ExecutorService outboxExecutorService(
-      ExecutorService candidateExecutorServices) {
-    return candidateExecutorServices;
   }
 
   @Bean

--- a/code/scs-outbox-libs/scs-outbox-core/src/test/java/dev/inditex/scsoutbox/config/ExecutorServiceAutoConfigurationTest.java
+++ b/code/scs-outbox-libs/scs-outbox-core/src/test/java/dev/inditex/scsoutbox/config/ExecutorServiceAutoConfigurationTest.java
@@ -50,8 +50,9 @@ class ExecutorServiceAutoConfigurationTest {
     void ignores_it_and_creates_its_own_default() {
       final Map<String, ExecutorService> beans = this.context.getBeansOfType(ExecutorService.class);
       System.out.println(beans);
-      assertThat(this.executorService).isEqualTo(beans.get("defaultOutboxExecutorService"));
-      assertThat(this.executorService).isNotEqualTo(beans.get("executorService"));
+      assertThat(this.executorService)
+          .isEqualTo(beans.get("defaultOutboxExecutorService"))
+          .isNotEqualTo(beans.get("executorService"));
     }
 
     @TestConfiguration
@@ -103,8 +104,9 @@ class ExecutorServiceAutoConfigurationTest {
     void ignores_it_and_creates_its_own_default() {
       final Map<String, ExecutorService> beans = this.context.getBeansOfType(ExecutorService.class);
       System.out.println(beans);
-      assertThat(this.executorService).isEqualTo(beans.get("defaultOutboxExecutorService"));
-      assertThat(this.executorService).isNotEqualTo(beans.get("primaryExecutorService"));
+      assertThat(this.executorService)
+          .isEqualTo(beans.get("defaultOutboxExecutorService"))
+          .isNotEqualTo(beans.get("primaryExecutorService"));
     }
 
     @TestConfiguration

--- a/code/scs-outbox-libs/scs-outbox-core/src/test/java/dev/inditex/scsoutbox/config/ExecutorServiceAutoConfigurationTest.java
+++ b/code/scs-outbox-libs/scs-outbox-core/src/test/java/dev/inditex/scsoutbox/config/ExecutorServiceAutoConfigurationTest.java
@@ -42,15 +42,16 @@ class ExecutorServiceAutoConfigurationTest {
 
   @Nested
   @SpringBootTest(
-      classes = {ExecutorServiceDefined.TestConfig.class, OutboxAutoConfiguration.class, RefreshAutoConfiguration.class},
+      classes = {UnrelatedExecutorServiceDefined.TestConfig.class, OutboxAutoConfiguration.class, RefreshAutoConfiguration.class},
       properties = {})
-  class ExecutorServiceDefined extends AbstractExecutorService {
+  class UnrelatedExecutorServiceDefined extends AbstractExecutorService {
 
     @Test
-    void uses_the_defined() {
+    void ignores_it_and_creates_its_own_default() {
       final Map<String, ExecutorService> beans = this.context.getBeansOfType(ExecutorService.class);
       System.out.println(beans);
-      assertThat(this.executorService).isEqualTo(beans.get("executorService"));
+      assertThat(this.executorService).isEqualTo(beans.get("defaultOutboxExecutorService"));
+      assertThat(this.executorService).isNotEqualTo(beans.get("executorService"));
     }
 
     @TestConfiguration
@@ -94,15 +95,16 @@ class ExecutorServiceAutoConfigurationTest {
 
   @Nested
   @SpringBootTest(
-      classes = {PrimaryExecutorServiceDefined.TestConfig.class, OutboxAutoConfiguration.class, RefreshAutoConfiguration.class},
+      classes = {UnrelatedPrimaryExecutorServiceDefined.TestConfig.class, OutboxAutoConfiguration.class, RefreshAutoConfiguration.class},
       properties = {})
-  class PrimaryExecutorServiceDefined extends AbstractExecutorService {
+  class UnrelatedPrimaryExecutorServiceDefined extends AbstractExecutorService {
 
     @Test
-    void uses_the_primary() {
+    void ignores_it_and_creates_its_own_default() {
       final Map<String, ExecutorService> beans = this.context.getBeansOfType(ExecutorService.class);
       System.out.println(beans);
-      assertThat(this.executorService).isEqualTo(beans.get("primaryExecutorService"));
+      assertThat(this.executorService).isEqualTo(beans.get("defaultOutboxExecutorService"));
+      assertThat(this.executorService).isNotEqualTo(beans.get("primaryExecutorService"));
     }
 
     @TestConfiguration


### PR DESCRIPTION
Closes #48