### PR TITLE
fix(docs): Remove erroneous 'sudo' from Code of Conduct link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,6 +8,6 @@ SPDX-License-Identifier: Apache-2.0
 
 By participating in this project, you agree to abide by the rules and principles outlined in the Code of Conduct. Please review it to understand the expectations for respectful and inclusive collaboration.
 
-This project adheres to the general [Inditex Tech Code of Conduct](https://github.com/sudo InditexTech/foss/blob/main/CODE_OF_CONDUCT.md).
+This project adheres to the general [Inditex Tech Code of Conduct](https://github.com/InditexTech/foss/blob/main/CODE_OF_CONDUCT.md).
 
 For any inquiries regarding this Code of Conduct, please contact us at oso@inditex.com.


### PR DESCRIPTION
Closes #55