### PR TITLE
fix(ci): use `asdf set` instead of removed `asdf local` in SonarCloud analysis

### DIFF
--- a/.github/workflows/code-maven_java-sonarcloud-analysis.yml
+++ b/.github/workflows/code-maven_java-sonarcloud-analysis.yml
@@ -113,9 +113,9 @@ jobs:
       - name: SonarCloud / Set asdf versions
         working-directory: code
         run: |
-          asdf local java ${{ env.SONAR_JAVA_VERSION }}
-          asdf local nodejs 20.10.0
-          asdf local maven 3.9.4
+          asdf set java ${{ env.SONAR_JAVA_VERSION }}
+          asdf set nodejs 20.10.0
+          asdf set maven 3.9.4
 
       - name: Setup Java environment vars
         working-directory: code

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#64](https://github.com/InditexTech/scs-outbox/pull/64) Use `asdf set` instead of the removed `asdf local` command in the SonarCloud analysis workflow, which failed on asdf 0.16+.
 - Replace project's long name with "Outbox for Spring Cloud Stream".
 
 ## [1.0.1] - 2026-07-28


### PR DESCRIPTION
## Summary

The `code-maven-sonarcloud-analysis` workflow fails at the **`SonarCloud / Set asdf versions`** step on every run, regardless of the change under test. See failing run: https://github.com/InditexTech/scs-outbox/actions/runs/32698690872/job/97345682972 (unit tests were fully green; only this step failed).

```
invalid command provided: local
version: v0.20.0
##[error]Process completed with exit code 1.
```

**Root cause:** asdf removed the `local`/`global` subcommands in **v0.16** (the Go rewrite) in favour of `asdf set`. The `asdf-vm/actions/install` step is SHA-pinned but does not pin the asdf **binary** version, so it installs the latest asdf (currently **v0.20.0**), where `asdf local` no longer exists.

**Fix:** replace `asdf local <tool> <version>` with its official successor `asdf set <tool> <version>` — same semantics (writes the version into `code/.tool-versions` in the working directory). No other behaviour changes.

Closes #63


## Checklist

- [x] Commits are **signed** (`git commit -S`)
- [x] Commit messages follow **Conventional Commits**
- [x] Documentation has been updated (CHANGELOG — see follow-up commit)
- [x] I have read and agree to the project’s [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I have signed the [Contributor License Agreement (CLA)](../CONTRIBUTING.md)

## Additional context

Verification is via this PR's own `SonarCloud` workflow run, which must reach and pass the `SonarCloud / Set asdf versions` step. A YAML-only change; the surrounding install steps already run on the same asdf v0.20.0 successfully (`asdf where`, tool install), so only the removed `asdf local` invocation was affected.